### PR TITLE
Support for opts.mkdirs in createWriteStream

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1906,27 +1906,9 @@ MantaClient.prototype.createWriteStream = function createWriteStream(p, opts) {
     assert.optionalObject(opts, 'options');
 
     opts = opts || {};
-    p = this.path(p);
 
-    var userHeaders = normalizeHeaders(opts.headers);
-    var options = createOptions({
-        accept: 'application/json',
-        contentType: (opts.type ||
-                      userHeaders['content-type'] ||
-                      mime.lookup(p)),
-        expect: '100-continue',
-        path: p
-    }, opts);
-    options.headers['transfer-encoding'] = 'chunked';
-    var log = this.log.child({
-        path: p,
-        req_id: options.id
-    }, true);
     var self = this;
     var stream = new PassThrough();
-
-    if (opts.copies)
-        options.headers['x-durability-level'] = parseInt(opts.copies, 10);
 
     var cb = once(function _cb(err, res) {
         if (err) {
@@ -1937,31 +1919,7 @@ MantaClient.prototype.createWriteStream = function createWriteStream(p, opts) {
         }
     });
 
-    self.signRequest({
-        headers: options.headers
-    }, function onSignRequest(err) {
-        if (err) {
-            cb(err);
-            return;
-        }
-
-        self.client.put(options, onRequestCallback({
-            cb: cb,
-            log: log,
-            name: 'put',
-            onResult: onResultCallback({
-                cb: cb,
-                log: log,
-                name: 'put'
-            }),
-            reqCb: function (req) {
-                req.once('continue', function onContinue() {
-                    log.debug('createWriteStream: continue received');
-                    stream.pipe(req);
-                });
-            }
-        }));
-    });
+    self.put(p, stream, opts, cb);
 
     return (stream);
 };


### PR DESCRIPTION
Intends to fix #248 by making a call to client.put() and returning the stream, as opposed to re-implementing similar logic to client.put(). 
