### PR TITLE
TritonDataCenter/node-manta#389 minfo should support json output TritonDataCenter/node-manta#388 Testing v1 features should be skipped unless mantav1 TOOLS-2543 MNX Tooling updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle.git
+	url = https://github.com/TritonDataCenter/jsstyle.git
 [submodule "deps/restdown"]
 	path = deps/restdown
-	url = https://github.com/trentm/restdown.git
+	url = https://github.com/TritonDataCenter/restdown.git
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+	url = https://github.com/TritonDataCenter/javascriptlint.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,18 +4,28 @@ See `CONTRIBUTING.md` for details on how to update this file
 
 ## not yet released
 
+## 5.3.0
+
+- [#389](https://github.com/TritonDataCenter/node-manta/issues/389) minfo should support json output
+- [#388](https://github.com/TritonDataCenter/node-manta/issues/388) Testing v1 features should be skipped unless mantav1
+- [TOOLS-2543](https://smartos.org/bugview/TOOLS-2543) MNX Tooling updates
+
+## 5.2.3
+
+- [TOOLS-2525] Everything needs to stop cloning with git:// URLs
+
 ## 5.2.2
 
-- [#313](https://github.com/joyent/node-manta/issues/313) mget -H option documented incorrectly
-- [#358](https://github.com/joyent/node-manta/issues/358) mchmod command stopped working after v5.1.1
-- [#361](https://github.com/joyent/node-manta/issues/361) expires-relative short option has wrong case in man page
-- [#349](https://github.com/joyent/node-manta/issues/349) issue numbers in
+- [#313](https://github.com/TritonDataCenter/node-manta/issues/313) mget -H option documented incorrectly
+- [#358](https://github.com/TritonDataCenter/node-manta/issues/358) mchmod command stopped working after v5.1.1
+- [#361](https://github.com/TritonDataCenter/node-manta/issues/361) expires-relative short option has wrong case in man page
+- [#349](https://github.com/TritonDataCenter/node-manta/issues/349) issue numbers in
   CHANGES.md should link to GitHub issues
-- [#335](https://github.com/joyent/node-manta/issues/335) Want option to confim
+- [#335](https://github.com/TritonDataCenter/node-manta/issues/335) Want option to confim
   removal of files for `mrm`
 
   `mrm -I` and `mrmdir -I` now supported
-- [#62](https://github.com/joyent/node-manta/issues/62) RFE - mls list with human readable format
+- [#62](https://github.com/TritonDataCenter/node-manta/issues/62) RFE - mls list with human readable format
 
   `mls` now supports `-h` for human readable output with `-l`, ie: `mls -lh`.
 
@@ -32,7 +42,7 @@ See `CONTRIBUTING.md` for details on how to update this file
 
 ## 5.2.0
 
-- [#61](https://github.com/joyent/node-manta/issues/61) msign should allow for
+- [#61](https://github.com/TritonDataCenter/node-manta/issues/61) msign should allow for
   friendlier expiry date formats
 
   `msign -E <expires>` now supported, e.g.
@@ -40,16 +50,16 @@ See `CONTRIBUTING.md` for details on how to update this file
       msign -E 30m ~~/stor/bar # 30 minutes from now
       msign -E 1h ~~/stor/foo  # 1 hour from now
 
-- [#333](https://github.com/joyent/node-manta/issues/333) The --role-tag option
+- [#333](https://github.com/TritonDataCenter/node-manta/issues/333) The --role-tag option
   does not work  for mput, muntar, mln, or mmkdir
-- [#329](https://github.com/joyent/node-manta/issues/329) Refactor all commands
+- [#329](https://github.com/TritonDataCenter/node-manta/issues/329) Refactor all commands
   to use common option parsing code
-- [#343](https://github.com/joyent/node-manta/issues/343) Want `mjob wait` as
+- [#343](https://github.com/TritonDataCenter/node-manta/issues/343) Want `mjob wait` as
   alias for `mjob watch`
 
 ## 5.1.1
 
-- [#315](https://github.com/joyent/node-manta/issues/315) document mlogin
+- [#315](https://github.com/TritonDataCenter/node-manta/issues/315) document mlogin
   session termination conditions
 
 ## 5.1.0
@@ -60,9 +70,9 @@ upload client operations. The client operations now allow for a
 which is used as the URL of the request. Otherwise, the parts directory is
 resolved using the server's redirect endpoint.
 
-- [#325](https://github.com/joyent/node-manta/issues/325) ask server for fully
+- [#325](https://github.com/TritonDataCenter/node-manta/issues/325) ask server for fully
   qualified upload path
-- [#326](https://github.com/joyent/node-manta/issues/326) client could support
+- [#326](https://github.com/TritonDataCenter/node-manta/issues/326) client could support
   accepting fully qualified upload directory as input to MPU operations
 
 ## 5.0.0
@@ -70,7 +80,7 @@ resolved using the server's redirect endpoint.
 If you do not check explicitly for `ResourceNotFoundErrors` from multipart
 upload operations, this major bump will not affect you. Code that checks for a
 `ResourceNotFoundError` in the error cause chain using
-[VError](https://github.com/joyent/node-verror)'s `findCauseByName` or
+[VError](https://github.com/TritonDataCenter/node-verror)'s `findCauseByName` or
 `hasCauseWithName` will continue to work.
 
 Major bump due to a change in the errors that may be returned from client
@@ -84,9 +94,9 @@ Code that specifically checks for the error name `ResourceNotFoundError` to
 detect whether multipart upload is supported should be updated appropriately
 to use VError.hasCauseWithName.
 
-- [#320](https://github.com/joyent/node-manta/issues/320) client should detect
+- [#320](https://github.com/TritonDataCenter/node-manta/issues/320) client should detect
   if MPU is enabled
-- [#319](https://github.com/joyent/node-manta/issues/319) MPU-related tests
+- [#319](https://github.com/TritonDataCenter/node-manta/issues/319) MPU-related tests
   should detect if MPU is supported
 
 ## 4.5.0
@@ -95,37 +105,37 @@ Minor bump due to a backwards-compatible addition to the `commitUpload` method
 on the client. The `commitUpload` method now passes the response from the server
 to the callback.
 
-- [#323](https://github.com/joyent/node-manta/issues/323) return response
+- [#323](https://github.com/TritonDataCenter/node-manta/issues/323) return response
   argument from client.commitUpload
-- [#318](https://github.com/joyent/node-manta/issues/318) node-manta nodejs
+- [#318](https://github.com/TritonDataCenter/node-manta/issues/318) node-manta nodejs
   version support
-- [#322](https://github.com/joyent/node-manta/issues/322) test7 make target
+- [#322](https://github.com/TritonDataCenter/node-manta/issues/322) test7 make target
   should be test8 given node v8
-- [#321](https://github.com/joyent/node-manta/issues/321) document mlogin's use
+- [#321](https://github.com/TritonDataCenter/node-manta/issues/321) document mlogin's use
   of poseidon assets
 
 ## 4.4.3
 
-- [#244](https://github.com/joyent/node-manta/issues/244) mlogin could disable
+- [#244](https://github.com/TritonDataCenter/node-manta/issues/244) mlogin could disable
   Manta's abort-on-core behavior
 
 ## 4.4.2
 
-- [#312](https://github.com/joyent/node-manta/issues/312) Custom header input
+- [#312](https://github.com/TritonDataCenter/node-manta/issues/312) Custom header input
   should tolerate ':' characters
 
 ## 4.4.1
 
-- [#302](https://github.com/joyent/node-manta/issues/302) Create a manual page
+- [#302](https://github.com/TritonDataCenter/node-manta/issues/302) Create a manual page
   for `mmpu`
-- [#311](https://github.com/joyent/node-manta/issues/311) `createUpload`
+- [#311](https://github.com/TritonDataCenter/node-manta/issues/311) `createUpload`
   incorrectly handles some target object headers
 
 ## 4.4.0
 
-- [#308](https://github.com/joyent/node-manta/issues/308) `mmpu commit` does
+- [#308](https://github.com/TritonDataCenter/node-manta/issues/308) `mmpu commit` does
   not parse options
-- [#309](https://github.com/joyent/node-manta/issues/309) MPU tests are out of
+- [#309](https://github.com/TritonDataCenter/node-manta/issues/309) MPU tests are out of
   sync with Muskie master branch implementation
 
 ## 4.3.0
@@ -137,32 +147,32 @@ to the callback.
 Minor bump due to relaxation of API requirements in `mfind` (NotFound
 errors are no longer fatal unless none of the arguments are found)
 
-- [#230](https://github.com/joyent/node-manta/issues/230) mlogin resists
+- [#230](https://github.com/TritonDataCenter/node-manta/issues/230) mlogin resists
   request-level debugging
-- [#298](https://github.com/joyent/node-manta/issues/298) mjob-simple fails
+- [#298](https://github.com/TritonDataCenter/node-manta/issues/298) mjob-simple fails
   because of GNU date regression
-- [#281](https://github.com/joyent/node-manta/issues/281) mfind NotFound errors
+- [#281](https://github.com/TritonDataCenter/node-manta/issues/281) mfind NotFound errors
   should not be fatal.
 
 ## 4.1.1
 
-- [#293](https://github.com/joyent/node-manta/issues/293) ~~ evaluation needs
+- [#293](https://github.com/TritonDataCenter/node-manta/issues/293) ~~ evaluation needs
   to be less pedantic
-- [#294](https://github.com/joyent/node-manta/issues/294) content-length and
+- [#294](https://github.com/TritonDataCenter/node-manta/issues/294) content-length and
   transfer-encoding chunked must not be used together
 
 ## 4.1.0
 
-- [#214](https://github.com/joyent/node-manta/issues/214) basic bash tab
+- [#214](https://github.com/TritonDataCenter/node-manta/issues/214) basic bash tab
   completion
-- [#288](https://github.com/joyent/node-manta/issues/288) mfind of file blows
+- [#288](https://github.com/TritonDataCenter/node-manta/issues/288) mfind of file blows
   assertion: "ent (object) is required"
 
 ## 4.0.0
 
-- [#272](https://github.com/joyent/node-manta/issues/272) `m*` tools should
+- [#272](https://github.com/TritonDataCenter/node-manta/issues/272) `m*` tools should
   have a `--version` option
-- [#282](https://github.com/joyent/node-manta/issues/282) mchmod ignores all(?)
+- [#282](https://github.com/TritonDataCenter/node-manta/issues/282) mchmod ignores all(?)
   options
 
   *BREAKING CHANGE* `mchmod` now parses all standard options. The use of the
@@ -174,12 +184,12 @@ errors are no longer fatal unless none of the arguments are found)
         mchmod -read,write ~~/stor/foo.txt      # worked before, fails in v4
         mchmod -- -read,write ~~/stor/foo.txt   # works in both major versions
 
-- [#280](https://github.com/joyent/node-manta/issues/280) job expressions do
+- [#280](https://github.com/TritonDataCenter/node-manta/issues/280) job expressions do
   not honor --memory
 
   Ensure that `--disk`, `--memory`, and `--init` options are used with `mjob
   create MAP_PHASE ^ MAP_PHASE ^^ REDUCE_PHASE` style job creation.
-- [#279](https://github.com/joyent/node-manta/issues/279) mjob should expressly
+- [#279](https://github.com/TritonDataCenter/node-manta/issues/279) mjob should expressly
   list out allowed sizes for memory
 
   Improvements to help output for all CLIs.  Also add the `mjob create
@@ -188,23 +198,23 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## 3.1.3
 
-- [#277](https://github.com/joyent/node-manta/issues/277) mjob fails with mjob:
+- [#277](https://github.com/TritonDataCenter/node-manta/issues/277) mjob fails with mjob:
   AssertionError: body (object) is required
 
 ## 3.1.2
 
-- [#275](https://github.com/joyent/node-manta/issues/275) msign with subusers
+- [#275](https://github.com/TritonDataCenter/node-manta/issues/275) msign with subusers
   broken
-- [#270](https://github.com/joyent/node-manta/issues/270) Add -p to man mput
+- [#270](https://github.com/TritonDataCenter/node-manta/issues/270) Add -p to man mput
 
 ## 3.1.1
 
-- [#261](https://github.com/joyent/node-manta/issues/261) "AssertionError:
+- [#261](https://github.com/TritonDataCenter/node-manta/issues/261) "AssertionError:
   undefined (object) is required" after "socket hang up"
 
 ## 3.1.0
 
-- [#265](https://github.com/joyent/node-manta/issues/265) `mfind --json,-j`
+- [#265](https://github.com/TritonDataCenter/node-manta/issues/265) `mfind --json,-j`
 
         $ mfind -j ~~/stor/tmp
         {"name":"foo-file.gz","etag":"142ad91b-73d8-6cb4-9cd9-efacf7df7a9a","size":229535627,"type":"object","mtime":"2014-10-08T22:53:25.146Z","durability":2,"parent":"/trent.mick/stor/tmp","depth":0}
@@ -212,7 +222,7 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## 3.0.0
 
-- [#246](https://github.com/joyent/node-manta/issues/246) Update dependencies
+- [#246](https://github.com/TritonDataCenter/node-manta/issues/246) Update dependencies
   for a Node v6 age.
   This involved dropping support for node 0.8. It is for this reason, and
   prudence at the large number of dependency updates (many of them across
@@ -222,12 +232,12 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## 2.0.7
 
-- [#252](https://github.com/joyent/node-manta/issues/252) 2.0.6 breaks msign
+- [#252](https://github.com/TritonDataCenter/node-manta/issues/252) 2.0.6 breaks msign
   with ssh-agent and RSA keys
 
 ## 2.0.6
 
-- [#250](https://github.com/joyent/node-manta/issues/250) msign should let
+- [#250](https://github.com/TritonDataCenter/node-manta/issues/250) msign should let
   smartdc-auth decide what algorithm to use
 
 ## 2.0.5
@@ -263,49 +273,49 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## 1.6.0
 
-- [#237](https://github.com/joyent/node-manta/issues/237) add
+- [#237](https://github.com/TritonDataCenter/node-manta/issues/237) add
   createListStream() API for streaming ls()
-- [#238](https://github.com/joyent/node-manta/issues/238) mls --type/-t option
+- [#238](https://github.com/TritonDataCenter/node-manta/issues/238) mls --type/-t option
   does not work
 
 ## 1.5.2
 
-- [#228](https://github.com/joyent/node-manta/issues/228) pipeline callback
+- [#228](https://github.com/TritonDataCenter/node-manta/issues/228) pipeline callback
   invoked after the pipeline has already completed
 
 ## 1.5.1
 
-- [#218](https://github.com/joyent/node-manta/issues/218) allow custom
+- [#218](https://github.com/TritonDataCenter/node-manta/issues/218) allow custom
   ssh-agent options to be passed to constructor
 
 ## 1.5.0
 
-- [#219](https://github.com/joyent/node-manta/issues/219) msign doesn't work on
+- [#219](https://github.com/TritonDataCenter/node-manta/issues/219) msign doesn't work on
   paths with # in them
-- [#220](https://github.com/joyent/node-manta/issues/220) signURL must
+- [#220](https://github.com/TritonDataCenter/node-manta/issues/220) signURL must
   URI-encode the Manta path
 
 ## 1.4.7
 
-- [#216](https://github.com/joyent/node-manta/issues/216) commands fail on
+- [#216](https://github.com/TritonDataCenter/node-manta/issues/216) commands fail on
   1.4.6 when using ssh-agent
-- [#215](https://github.com/joyent/node-manta/issues/215)
+- [#215](https://github.com/TritonDataCenter/node-manta/issues/215)
   client.createReadStream should emit an 'open' event like fs.createReadStream
-- [#208](https://github.com/joyent/node-manta/issues/208) mget fails for large
+- [#208](https://github.com/TritonDataCenter/node-manta/issues/208) mget fails for large
   files over slow internet
 
 ## 1.4.6
 
-- [#210](https://github.com/joyent/node-manta/issues/210) use path.posix when
+- [#210](https://github.com/TritonDataCenter/node-manta/issues/210) use path.posix when
   dealing with manta paths
-- [#206](https://github.com/joyent/node-manta/issues/206) mget/mput: draw
+- [#206](https://github.com/TritonDataCenter/node-manta/issues/206) mget/mput: draw
   progress bar to /dev/tty with `--progress`
-- [#200](https://github.com/joyent/node-manta/issues/200) combining implicit
+- [#200](https://github.com/TritonDataCenter/node-manta/issues/200) combining implicit
   phases with -m/-r flags drops phases
 
 ## 1.4.5
 
-- [#203](https://github.com/joyent/node-manta/issues/203) --account/-a doesn't
+- [#203](https://github.com/TritonDataCenter/node-manta/issues/203) --account/-a doesn't
   work
 
 ## 1.4.4
@@ -319,7 +329,7 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## 1.4.2
 
-- [#201](https://github.com/joyent/node-manta/issues/201) mget does not respect
+- [#201](https://github.com/TritonDataCenter/node-manta/issues/201) mget does not respect
   destination backpressure
 
 ## 1.4.1
@@ -334,7 +344,7 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## 1.3.1
 
-- [#197](https://github.com/joyent/node-manta/issues/197) mjob create -s
+- [#197](https://github.com/TritonDataCenter/node-manta/issues/197) mjob create -s
   ~~/stor//foo broken in 1.3.0
 
 ## 1.3.0
@@ -345,45 +355,45 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## v1.2.8
 
-- [#187](https://github.com/joyent/node-manta/issues/187) mlogin should support
+- [#187](https://github.com/TritonDataCenter/node-manta/issues/187) mlogin should support
   session control escape character
-- [#188](https://github.com/joyent/node-manta/issues/188) mjob help and
+- [#188](https://github.com/TritonDataCenter/node-manta/issues/188) mjob help and
   documentation nits
-- [#191](https://github.com/joyent/node-manta/issues/191) signURL is not well
+- [#191](https://github.com/TritonDataCenter/node-manta/issues/191) signURL is not well
   documented
-- [#194](https://github.com/joyent/node-manta/issues/194) mjob create -o emits
+- [#194](https://github.com/TritonDataCenter/node-manta/issues/194) mjob create -o emits
   "socket hang up"
 
 ## v1.2.7
 
 - include restify v2.8.0
-- [#184](https://github.com/joyent/node-manta/issues/184) update progbar to
+- [#184](https://github.com/TritonDataCenter/node-manta/issues/184) update progbar to
   0.1.0
-- [#181](https://github.com/joyent/node-manta/issues/181) `client.get()` should
+- [#181](https://github.com/TritonDataCenter/node-manta/issues/181) `client.get()` should
   retry/resume downloads when disconnected
-- [#180](https://github.com/joyent/node-manta/issues/180) Make invalid key more
+- [#180](https://github.com/TritonDataCenter/node-manta/issues/180) Make invalid key more
   clear
-- [#179](https://github.com/joyent/node-manta/issues/179) mlogin(1) should
+- [#179](https://github.com/TritonDataCenter/node-manta/issues/179) mlogin(1) should
   allow image selection
-- [#177](https://github.com/joyent/node-manta/issues/177) `mls: TypeError:
+- [#177](https://github.com/TritonDataCenter/node-manta/issues/177) `mls: TypeError:
   Arguments to path.join must be strings` if "HOME" isn't set
-- [#156](https://github.com/joyent/node-manta/issues/156) mjob list with spaces
+- [#156](https://github.com/TritonDataCenter/node-manta/issues/156) mjob list with spaces
   in name causes "mjob: error: undefined"
-- [#167](https://github.com/joyent/node-manta/issues/167) can't upload a zero
+- [#167](https://github.com/TritonDataCenter/node-manta/issues/167) can't upload a zero
   byte file stream without setting content-length
-- [#168](https://github.com/joyent/node-manta/issues/168) mls -l gives wrong
+- [#168](https://github.com/TritonDataCenter/node-manta/issues/168) mls -l gives wrong
   timestamp
 
 ## v1.2.6
 
-- [#161](https://github.com/joyent/node-manta/issues/161) Add headers to mget,
+- [#161](https://github.com/TritonDataCenter/node-manta/issues/161) Add headers to mget,
   as well as an minfo (HEAD) tool
-- [#164](https://github.com/joyent/node-manta/issues/164) mjob/mlogin "-s"
+- [#164](https://github.com/TritonDataCenter/node-manta/issues/164) mjob/mlogin "-s"
   should not url-encode asset paths
 
 ## v1.2.5
 
-- [#149](https://github.com/joyent/node-manta/issues/149) mput -f fails on
+- [#149](https://github.com/TritonDataCenter/node-manta/issues/149) mput -f fails on
   empty file
 - mls spewing a random mls: [object Object] at end of listings
 
@@ -395,7 +405,7 @@ errors are no longer fatal unless none of the arguments are found)
 
 - `client.mkdir` should return the same object as `client.info`
 - add `path` API to manta client
-- [#157](https://github.com/joyent/node-manta/issues/157) mput -p handles
+- [#157](https://github.com/TritonDataCenter/node-manta/issues/157) mput -p handles
   spaces incorrectly
 - depend on restify from npm, not git
 
@@ -409,28 +419,28 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## v1.2.0
 
-- [#147](https://github.com/joyent/node-manta/issues/147) msign: broken on urls
+- [#147](https://github.com/TritonDataCenter/node-manta/issues/147) msign: broken on urls
   with spaces
-- [#140](https://github.com/joyent/node-manta/issues/140) sshAgentSigner not
+- [#140](https://github.com/TritonDataCenter/node-manta/issues/140) sshAgentSigner not
   caching well enough
-- [#138](https://github.com/joyent/node-manta/issues/138) mjob/mlogin should
+- [#138](https://github.com/TritonDataCenter/node-manta/issues/138) mjob/mlogin should
   support `~~` for assets.
-- [#132](https://github.com/joyent/node-manta/issues/132) mput should handle
+- [#132](https://github.com/TritonDataCenter/node-manta/issues/132) mput should handle
   files that are concurrently being appended to
-- [#131](https://github.com/joyent/node-manta/issues/131) add mjob cost
-- [#130](https://github.com/joyent/node-manta/issues/130) mput should
+- [#131](https://github.com/TritonDataCenter/node-manta/issues/131) add mjob cost
+- [#130](https://github.com/TritonDataCenter/node-manta/issues/130) mput should
   optionally calculate and send content-md5
-- [#128](https://github.com/joyent/node-manta/issues/128) want default
+- [#128](https://github.com/TritonDataCenter/node-manta/issues/128) want default
   content-type header env var
-- [#117](https://github.com/joyent/node-manta/issues/117) mfind add mindepth
+- [#117](https://github.com/TritonDataCenter/node-manta/issues/117) mfind add mindepth
   and maxdepth options
-- [#106](https://github.com/joyent/node-manta/issues/106) Add possibility for
+- [#106](https://github.com/TritonDataCenter/node-manta/issues/106) Add possibility for
   recursive listing in MantaClient#ls()
-- [#103](https://github.com/joyent/node-manta/issues/103) mls should have an
+- [#103](https://github.com/TritonDataCenter/node-manta/issues/103) mls should have an
   option to print out all headers
-- [#86](https://github.com/joyent/node-manta/issues/86) feature req: allow put
+- [#86](https://github.com/TritonDataCenter/node-manta/issues/86) feature req: allow put
   API to create missing folders automatically
-- [#59](https://github.com/joyent/node-manta/issues/59) would like mls -j to
+- [#59](https://github.com/TritonDataCenter/node-manta/issues/59) would like mls -j to
   include durability and mtime
 
 ## v1.1.2
@@ -440,64 +450,64 @@ errors are no longer fatal unless none of the arguments are found)
 
 ## v1.1.1
 
-- [#122](https://github.com/joyent/node-manta/issues/122) "mjob share" fails
+- [#122](https://github.com/TritonDataCenter/node-manta/issues/122) "mjob share" fails
   when optional readme not specified
-- [#114](https://github.com/joyent/node-manta/issues/114) auth: sshAgentSigner
+- [#114](https://github.com/TritonDataCenter/node-manta/issues/114) auth: sshAgentSigner
   now works
 
 ## v1.1.0
 
-- [#119](https://github.com/joyent/node-manta/issues/119) want "mjob share"
+- [#119](https://github.com/TritonDataCenter/node-manta/issues/119) want "mjob share"
   subcommand
-- [#109](https://github.com/joyent/node-manta/issues/109) mlogin(1) should
+- [#109](https://github.com/TritonDataCenter/node-manta/issues/109) mlogin(1) should
   print diagnostics on a failed or retried job
-- [#108](https://github.com/joyent/node-manta/issues/108) mlogin(1) should
+- [#108](https://github.com/TritonDataCenter/node-manta/issues/108) mlogin(1) should
   validate input object before creating job
-- [#110](https://github.com/joyent/node-manta/issues/110) muntar should retry
+- [#110](https://github.com/TritonDataCenter/node-manta/issues/110) muntar should retry
   files on a 500
-- [#101](https://github.com/joyent/node-manta/issues/101) MantaClient#put api
+- [#101](https://github.com/TritonDataCenter/node-manta/issues/101) MantaClient#put api
   suggestion
-- [#96](https://github.com/joyent/node-manta/issues/96) mls behavior isn't
+- [#96](https://github.com/TritonDataCenter/node-manta/issues/96) mls behavior isn't
   consistent as we descent a 'directory' tree from the manta 'root'
-- [#98](https://github.com/joyent/node-manta/issues/98) mls silently fails if
+- [#98](https://github.com/TritonDataCenter/node-manta/issues/98) mls silently fails if
   you don't have an rsa public key
-- [#97](https://github.com/joyent/node-manta/issues/97) mlogin(1) and msign(1)
+- [#97](https://github.com/TritonDataCenter/node-manta/issues/97) mlogin(1) and msign(1)
   broken with trailing slash in MANTA_URL
-- [#95](https://github.com/joyent/node-manta/issues/95) mlogin(1) should
+- [#95](https://github.com/TritonDataCenter/node-manta/issues/95) mlogin(1) should
   support --init
-- [#67](https://github.com/joyent/node-manta/issues/67) "mjob create" should
+- [#67](https://github.com/TritonDataCenter/node-manta/issues/67) "mjob create" should
   notify when input stream left open
-- [#32](https://github.com/joyent/node-manta/issues/32) obscure errors for
+- [#32](https://github.com/TritonDataCenter/node-manta/issues/32) obscure errors for
   invalid Manta URL from `mls` and `mput`
-- [#70](https://github.com/joyent/node-manta/issues/70) msign(1) with query
+- [#70](https://github.com/TritonDataCenter/node-manta/issues/70) msign(1) with query
   string is more like msigh
-- [#81](https://github.com/joyent/node-manta/issues/81) msign(1) should
+- [#81](https://github.com/TritonDataCenter/node-manta/issues/81) msign(1) should
   URI-encode before signing
-- [#74](https://github.com/joyent/node-manta/issues/74) the --limit (or -l )
+- [#74](https://github.com/TritonDataCenter/node-manta/issues/74) the --limit (or -l )
   switch for "mfind" does nothing
-- [#93](https://github.com/joyent/node-manta/issues/93) CLI commands should
+- [#93](https://github.com/TritonDataCenter/node-manta/issues/93) CLI commands should
   support `~~/(stor|public|...)`
-- [#91](https://github.com/joyent/node-manta/issues/91) "mrm -r" should work on
+- [#91](https://github.com/TritonDataCenter/node-manta/issues/91) "mrm -r" should work on
   an object
-- [#92](https://github.com/joyent/node-manta/issues/92) `getPath` should assert
+- [#92](https://github.com/TritonDataCenter/node-manta/issues/92) `getPath` should assert
   that the thing being passed in is actually a path
 - documentation fixes
 
 ## v1.0.1
 
 - MANTA-1617: mlogin: broken with xargs
-- [#78](https://github.com/joyent/node-manta/issues/78) mput should not retry
+- [#78](https://github.com/TritonDataCenter/node-manta/issues/78) mput should not retry
   on PreconditionFailedError (HTTP 412)
 - MANTA-1611: support PUT requests from browsers
 -- add helper signURL function to client
 -- tack properties on sshAgentSigner
 -- OpenSSL wants all algorithms in uppercase
 - MANTA-1593: client needs to URL encode all URLs sanely
--- [#79](https://github.com/joyent/node-manta/issues/79) mmkdir -p erroneously
+-- [#79](https://github.com/TritonDataCenter/node-manta/issues/79) mmkdir -p erroneously
   encodes directory names twice
--- [#80](https://github.com/joyent/node-manta/issues/80) "mrm -r" double-encodes
+-- [#80](https://github.com/TritonDataCenter/node-manta/issues/80) "mrm -r" double-encodes
   object names
-- [#72](https://github.com/joyent/node-manta/issues/72)
+- [#72](https://github.com/TritonDataCenter/node-manta/issues/72)
   {options:{headers:{'content-length':undefined}} to client.put causes socket
   errors
 - documentation fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-This repository is part of the Joyent Manta project.  See the [contribution
+This repository is part of the Triton Manta project.  See the [contribution
 guidelines for the Manta
-project](https://github.com/joyent/manta/blob/master/CONTRIBUTING.md).
+project](https://github.com/TritonDataCenter/manta/blob/master/CONTRIBUTING.md).
 
 In addition to the guidelines described there, user-facing changes should
 include an update to `CHANGES.md` (to list the change) and `package.json` (to
@@ -13,7 +13,7 @@ changelog you can use the included script `./tools/changelog-issue-line`
 (requires [json](https://github.com/trentm/json) to be installed).  Example:
 
     $ ./tools/changelog-issue-line 349
-    - [#349](https://github.com/joyent/node-manta/issues/349) issue numbers in CHANGES.md should link to GitHub issues
+    - [#349](https://github.com/TritonDataCenter/node-manta/issues/349) issue numbers in CHANGES.md should link to GitHub issues
 
 Or in `vim`
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # Manta Client Tools and SDK
 
-[manta](http://apidocs.joyent.com/manta/nodesdk.html) is a Node.js SDK for
-interacting with Joyent's Manta system.
+[manta](http://apidocs.tritondatacenter.com/manta/nodesdk.html) is a Node.js SDK for
+interacting with Triton's Manta system.
 
-This repository is part of the Joyent [Manta](http://github.com/joyent/manta)
+This repository is part of the Triton [Manta](http://github.com/TritonDataCenter/manta)
 project.  See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
-# Installation
+## Installation
 
 [Node.js](https://nodejs.org/) must be installed.
 
-## Command line utilities
+### Command line utilities
 
-### Install Globally
+#### Install Globally
 
 To install globally (to use the CLI tools) you can try running:
 
-    $ npm install -g manta
+    npm install -g manta
 
 Note that this might require `sudo` or escalated privileges to install
 properly.  This can often result in permissions errors or other failures - in
 that case try the below method.
 
-### Install Globally to a User Directory
+#### Install Globally to a User Directory
 
 Based on the [npm guide to prevent permissions
 errors](https://docs.npmjs.com/getting-started/fixing-npm-permissions#option-two-change-npms-default-directory),
@@ -43,13 +43,13 @@ export PATH=$PATH:~/.npm-global/bin
 export MANPATH=$MANPATH:~/.npm-global/share/man
 ```
 
-## Node.js module
+### Node.js module
 
 To install locally as a module (to use the SDK).
 
     $ npm install manta
 
-### Bash completion
+#### Bash completion
 
 Optionally install Bash completion. This is done by `source`ing the
 `share/manta.completion` file that is installed with the tools.
@@ -68,12 +68,12 @@ the following:
     --fulljson  --json      --marker    --subuser   --url       --version
     --help      --keyId     --reverse   --time      --user
 
-# Usage
+## Usage
 
-First setup your environment to match your Joyent Manta account:
+First setup your environment to match your Manta account:
 
     $ export MANTA_KEY_ID=$(ssh-keygen -l -f ~/.ssh/id_rsa.pub | awk '{print $2}')
-    $ export MANTA_URL=https://us-east.manta.joyent.com
+    $ export MANTA_URL=https://us-central.mnx.io
     $ export MANTA_USER=mark
 
 Alternatively, you can pull your ssh key out of your `ssh-agent` if you are
@@ -81,7 +81,7 @@ using one (this snippet takes the first key in the agent).
 
     $ export MANTA_KEY_ID=$(ssh-add -l | awk '{print $2}' | head -1)
 
-## SDK
+### SDK
 
 Then a code snippet:
 
@@ -120,7 +120,7 @@ client.get('/mark/stor/foo', function (err, stream) {});
 client.get('~~/stor/foo', function (err, stream) {});
 ```
 
-## CLI
+### CLI
 
 Basic commands include:
 
@@ -133,13 +133,12 @@ Basic commands include:
 
 A full set of commands for interacting with Manta is in `bin`.
 
-# More documentation
+## More documentation
 
-Docs can be found here:
-[http://apidocs.joyent.com/manta/](http://apidocs.joyent.com/manta/)
+Docs can be found here: <http://apidocs.tritondatacenter.com/manta/>
 
 
-# Testing
+## Testing
 
 node-manta has both unit tests ("test/unit/*.test.js") and integration tests
 ("test/integration/*.test.js"). Integration tests require `MANTA_` envvars for
@@ -157,7 +156,7 @@ Usage:
 Test output is node-tap's default "classic" output. Full TAP output is written
 to "test.tap". You can use `TAP=1` to have TAP output emited to stdout.
 
-## Test vars
+### Test vars
 
 The following `MANTA_...` envvars configure the test run and `TEST_...`
 envvars can tweak how the tests are run. As well, a number of node-tap
@@ -191,13 +190,13 @@ on those.
 - `TAP=1` to have the test suite emit TAP output. This is a node-tap envvar.
 
 
-## Testing Development Guide
+### Testing Development Guide
 
 - Unit tests (i.e. not requiring the Manta endpoint) in "unit/\*.test.js".
   Integration tests "integration/\*.test.js".
 
 - We are using node-tap. Read [RFD
-  139](https://github.com/joyent/rfd/blob/master/rfd/0139/README.md#guidelines-for-using-node-tap-in-triton-repos)
+  139](https://github.com/TritonDataCenter/rfd/blob/master/rfd/0139/README.md#guidelines-for-using-node-tap-in-triton-repos)
   for some guidelines for node-tap usage. The more common we can make some
   basic usage patterns in the many Triton and Manta repos, the easier the
   maintenance.
@@ -209,12 +208,13 @@ on those.
     - Prefer more and smaller and more targeted test files.
 
 
-# License
+## License
 
 ```
 The MIT License (MIT)
 
 Copyright (c) 2018, Joyent, Inc.
+Copyright 2022 MNX Cloud, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -236,12 +236,12 @@ SOFTWARE.
 ```
 
 
-# Bugs
+## Bugs
 
-See https://github.com/joyent/node-manta/issues.
+See https://github.com/TritonDataCenter/node-manta/issues.
 
 
-# Release process
+## Release process
 
 Here is how to cut a release:
 
@@ -266,7 +266,7 @@ Here is how to cut a release:
    This will run a couple checks (clean working copy, versions in package.json
    and CHANGES.md match), then will git tag and npm publish.
 
-# Supported Node.js Versions
+## Supported Node.js Versions
 
 Currently, node-manta is officially supported on the following node versions:
 

--- a/bin/minfo
+++ b/bin/minfo
@@ -2,6 +2,7 @@
 // -*- mode: js -*-
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 var http = require('http');
@@ -17,7 +18,17 @@ var manta = require('../lib');
 
 function optionsParser(name) {
     var parser = dashdash.createParser({
-        options: manta.DEFAULT_CLI_OPTIONS
+        options: manta.DEFAULT_CLI_OPTIONS.concat([
+            {
+                group: name + ' options'
+            },
+            {
+                names: [ 'json', 'j' ],
+                type: 'bool',
+                help: 'JSON output. Additional fields \'status\' and \
+                \'statusCode\' will be included in the output object.'
+            }
+        ])
     });
 
     return (parser);
@@ -68,7 +79,17 @@ function printEntry(res) {
         client.info(p, function (err, info, res) {
             if (err)
                 res = info;
-            printEntry(res);
+            if (options.json) {
+                var status = 'HTTP/' + res.httpVersion + ' ' + res.statusCode +
+                    ' ' + http.STATUS_CODES[res.statusCode];
+                var h = Object.assign({
+                    status: status,
+                    statusCode: res.statusCode
+                }, res.headers);
+                console.log(JSON.stringify(h));
+            } else {
+                printEntry(res);
+            }
             get();
         });
     }

--- a/bin/mjob
+++ b/bin/mjob
@@ -2,6 +2,7 @@
 // -*- mode: js -*-
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 var EventEmitter = require('events').EventEmitter;
@@ -942,7 +943,7 @@ MJob.prototype.do_create.help = [
     'specified with -m/-r; if using expression style, they apply to *all* phases.',
     'For documentation on phase properties, including supported values for --disk',
     'and --memory see:',
-    '    https://apidocs.joyent.com/manta/jobs-reference.html#job-configuration',
+    '    https://apidocs.tritondatacenter.com/manta/jobs-reference.html#job-configuration',
     '',
     'Input objects can be fed to a Manta job via stdin to `mjob create`:',
     '    mfind -t o ~~/stor/data | mjob create -m "grep foo || true" -r sort',

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
-title: Node.js SDK for Joyent Manta
+title: Node.js SDK for Manta
 markdown2extras: wiki-tables, code-friendly
 apisections: Directories, Objects, Links
 ---
 
-# Node.js SDK for Joyent Manta
+# Node.js SDK for Manta
 
 This is the reference documentation for the Manta [Node.js](http://nodejs.org/)
-SDK.  Manta is Joyent's Object Storage Service, which enables you to store data
+SDK.  Manta is Triton's Object Storage Service, which enables you to store data
 in the cloud and process that data using a built-in compute facility.
 
 This document explains the Node.js API interface and describes the various
@@ -17,7 +17,7 @@ operations, structures and error codes.
 
 Any content formatted like this:
 
-    $ curl -is https://us-east.manta.joyent.com
+    $ curl -is https://us-central.mnx.io
 
 is a command-line example that you can run from a shell. All other examples and
 information are formatted like this:
@@ -47,7 +47,7 @@ The shell command below simply parses the SSH fingerprint and sets that in the
 requisite environment variable.
 
     $ export MANTA_KEY_ID=`ssh-keygen -l -f ~/.ssh/id_rsa.pub | awk '{print $2}' | tr -d '\n'`
-    $ export MANTA_URL=https://us-east.manta.joyent.com/
+    $ export MANTA_URL=https://us-central.mnx.io/
     $ export MANTA_USER=jill
 
 # Creating a Client
@@ -128,7 +128,7 @@ the correct canonicalization for a URL:
         var opts = {
             algorithm: 'RSA-SHA256',
             expires: Math.floor(Date.now() / 1000) + 3600, // epoch time
-            host: 'us-east.manta.joyent.com',
+            host: 'us-central.mnx.io',
             keyId: process.env.MANTA_KEY_ID,
             path: '/mark/stor/my_image.png',
             sign: manta.privateKeySigner({
@@ -142,7 +142,7 @@ the correct canonicalization for a URL:
         manta.signUrl(opts, function (err, resource) {
             assert.ifError(err);
 
-            console.log('https://us-east.manta.joyent.com' + resource);
+            console.log('https://us-central.mnx.io' + resource);
         });
 
 ## Common API options

--- a/docs/man/mchattr.md
+++ b/docs/man/mchattr.md
@@ -52,7 +52,7 @@ OPTIONS
   Specify which roles to assume for the request.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `--user user`
   Authenticate as user under account.
@@ -98,4 +98,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mchmod.md
+++ b/docs/man/mchmod.md
@@ -54,7 +54,7 @@ OPTIONS
   Specify which roles to assume for the request.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `--user user`
   Authenticate as user under account.
@@ -100,4 +100,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mfind.md
+++ b/docs/man/mfind.md
@@ -23,7 +23,7 @@ supports Regular Expression matching.
 
 With the `--json` option a stream of JSON objects is printed. Each JSON object
 contains the fields from the Manta [ListDirectory API
-endpoint](https://apidocs.joyent.com/manta/api.html#ListDirectory), plus the
+endpoint](https://apidocs.tritondatacenter.com/manta/api.html#ListDirectory), plus the
 following client-side added fields:
 
 - `depth`: An integer directory depth under the given directory,
@@ -91,7 +91,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -133,4 +133,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mget.md
+++ b/docs/man/mget.md
@@ -78,7 +78,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -120,4 +120,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/minfo.md
+++ b/docs/man/minfo.md
@@ -49,7 +49,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -92,4 +92,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/minfo.md
+++ b/docs/man/minfo.md
@@ -38,6 +38,10 @@ OPTIONS
   SSL connections are attempted to be made secure by using the CA certificate
   bundle installed by default.
 
+`-j, --json`
+  Output object headers in JSON format. Additionally, `status` and `statusCode`,
+  while not technically headers, will be included in the output object.
+
 `-k, --key fingerprint`
   Authenticate using the SSH key described by FINGERPRINT.  The key must
   either be in `~/.ssh` or loaded in the SSH agent via `ssh-add`.

--- a/docs/man/mjob.md
+++ b/docs/man/mjob.md
@@ -54,7 +54,7 @@ The following options are supported in all commands:
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -351,4 +351,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mln.md
+++ b/docs/man/mln.md
@@ -55,7 +55,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -98,4 +98,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mlogin.md
+++ b/docs/man/mlogin.md
@@ -131,7 +131,7 @@ The options are supported:
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -168,4 +168,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mls.md
+++ b/docs/man/mls.md
@@ -72,7 +72,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -115,4 +115,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mmkdir.md
+++ b/docs/man/mmkdir.md
@@ -52,7 +52,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -95,4 +95,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mmpu.md
+++ b/docs/man/mmpu.md
@@ -57,7 +57,7 @@ The following options are supported in all commands:
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -265,4 +265,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mput.md
+++ b/docs/man/mput.md
@@ -88,7 +88,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -131,4 +131,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mrm.md
+++ b/docs/man/mrm.md
@@ -57,7 +57,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -100,4 +100,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/mrmdir.md
+++ b/docs/man/mrmdir.md
@@ -49,7 +49,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -92,4 +92,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/msign.md
+++ b/docs/man/msign.md
@@ -91,7 +91,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -134,4 +134,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/docs/man/muntar.md
+++ b/docs/man/muntar.md
@@ -86,7 +86,7 @@ OPTIONS
   Authenticate as user under account.
 
 `-u, --url url`
-  Manta base URL (such as `https://manta.us-east.joyent.com`).
+  Manta base URL (such as `https://us-central.manta.mnx.io`).
 
 `-v, --verbose`
   Print debug output to stderr.  Repeat option to increase verbosity.
@@ -133,4 +133,4 @@ BUGS
 
 DSA keys do not work when loaded via the SSH agent.
 
-Report bugs at [Github](https://github.com/joyent/node-manta/issues)
+Report bugs at [Github](https://github.com/TritonDataCenter/node-manta/issues)

--- a/examples/client-trace-logging.js
+++ b/examples/client-trace-logging.js
@@ -4,7 +4,7 @@
  * *client-side* of talking to Manta.
  *
  * Usage:
- *      git clone git@github.com:joyent/node-manta.git
+ *      git clone https://github.com/TritonDataCenter/node-manta.git
  *      cd node-manta
  *      npm install
  *      node examples/client-trace-logging.js | bunyan

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 var EventEmitter = require('events').EventEmitter;
@@ -750,8 +751,8 @@ MantaClient.prototype.chattr = function chattr(p, opts, cb) {
      * implicitly set the Content-Length header if it was known and avoid
      * chunked encoding. IIUC this was for perf gains. This caused a conflict
      * with the Manta webapi "PutMetadata" endpoint
-     * (https://apidocs.joyent.com/manta/api.html#PutMetadata) which would
-     * error with:
+     * (https://apidocs.tritondatacenter.com/manta/api.html#PutMetadata) which
+     * would error with:
      *     InvalidUpdateError: overwrite of "content-length" forbidden ...
      * if Content-Length was passed in. See MANTA-2929/MANTA-2937.
      *

--- a/man/man1/mchattr.1
+++ b/man/man1/mchattr.1
@@ -45,7 +45,7 @@ either be in \fB\fC~/.ssh\fR or loaded in the SSH agent via \fB\fCssh\-add\fR\&.
 Specify which roles to assume for the request.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-\-user user\fR
 Authenticate as user under account.
@@ -89,4 +89,4 @@ $ mchattr \-v ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mchmod.1
+++ b/man/man1/mchmod.1
@@ -45,7 +45,7 @@ either be in \fB\fC~/.ssh\fR or loaded in the SSH agent via \fB\fCssh\-add\fR\&.
 Specify which roles to assume for the request.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-\-user user\fR
 Authenticate as user under account.
@@ -89,4 +89,4 @@ $ mchmod \-v ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mfind.1
+++ b/man/man1/mfind.1
@@ -16,7 +16,7 @@ supports Regular Expression matching.
 .PP
 With the \fB\fC\-\-json\fR option a stream of JSON objects is printed. Each JSON object
 contains the fields from the Manta ListDirectory API
-endpoint \[la]https://apidocs.joyent.com/manta/api.html#ListDirectory\[ra], plus the
+endpoint \[la]https://apidocs.tritondatacenter.com/manta/api.html#ListDirectory\[ra], plus the
 following client\-side added fields:
 .RS
 .IP \(bu 2
@@ -86,7 +86,7 @@ Specify which roles to assume for the request.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -127,4 +127,4 @@ $ mfind \-vv ~~/stor 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mget.1
+++ b/man/man1/mget.1
@@ -83,7 +83,7 @@ Do not display a progress meter.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -124,4 +124,4 @@ $ mget \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/minfo.1
+++ b/man/man1/minfo.1
@@ -46,7 +46,7 @@ Specify which roles to assume for the request.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -87,4 +87,4 @@ $ minfo \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/minfo.1
+++ b/man/man1/minfo.1
@@ -35,6 +35,10 @@ This option explicitly allows "insecure" SSL connections and transfers.  All
 SSL connections are attempted to be made secure by using the CA certificate
 bundle installed by default.
 .TP
+\fB\fC\-j, \-\-json\fR
+Output object headers in JSON format. Additionally, \fB\fCstatus\fR and \fB\fCstatusCode\fR,
+while not technically headers, will be included in the output object.
+.TP
 \fB\fC\-k, \-\-key fingerprint\fR
 Authenticate using the SSH key described by FINGERPRINT.  The key must
 either be in \fB\fC~/.ssh\fR or loaded in the SSH agent via \fB\fCssh\-add\fR\&.

--- a/man/man1/mjob.1
+++ b/man/man1/mjob.1
@@ -45,7 +45,7 @@ Specify which roles to assume for the request.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -56,8 +56,8 @@ The following commands and options are supported:
 .PP
 Creates a job that executes the commands against keys that will be specified
 via \fB\fCaddinputs\fR\&.  \fB\fCexpression\fR can specify an arbitrary UNIX pipeline, with
-map/reduce \fIphases\fP separated by the \fB\fC^\fR or \fB\fC^^\fR
-.BR character (s),
+map/reduce \fIphases\fP separated by the \fB\fC^\fR or \fB\fC^^\fR 
+.BR character (s), 
 respectively.
 .PP
 For example, to specify a simple \fB\fCgrep | sort | uniq\fR job in Manta, the
@@ -219,7 +219,7 @@ $ mjob get 3ec32136\-b125\-11e2\-8487\-1b418dd6974b
 .RE
 .SS watch JOB
 .PP
-Waits for a given job to reach the \fB\fCdone\fR state. Aliases: wait.
+Waits for a given job to reach the \fB\fCdone\fR state.
 .PP
 .RS
 .nf
@@ -379,4 +379,4 @@ $ mjob \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mln.1
+++ b/man/man1/mln.1
@@ -48,7 +48,7 @@ Set the role tags on the created link.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -89,4 +89,4 @@ $ mln \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mlogin.1
+++ b/man/man1/mlogin.1
@@ -127,7 +127,7 @@ Specifies an asset to make available in the compute zone.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -160,5 +160,4 @@ where \fB\fC:login\fR is the account login name.
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github
-\[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mls.1
+++ b/man/man1/mls.1
@@ -65,7 +65,7 @@ sort by modification time, newest first
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -106,4 +106,4 @@ $ mls \-vv ~~/stor 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mmkdir.1
+++ b/man/man1/mmkdir.1
@@ -47,7 +47,7 @@ Set the role tags on the created directory.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -88,4 +88,4 @@ $ mmkdir \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mmpu.1
+++ b/man/man1/mmpu.1
@@ -48,7 +48,7 @@ Specify which roles to assume for the request.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -268,4 +268,4 @@ $ mmpu create \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mput.1
+++ b/man/man1/mput.1
@@ -89,7 +89,7 @@ Set the role tags on the created object.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -130,4 +130,4 @@ $ mput \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mrm.1
+++ b/man/man1/mrm.1
@@ -50,7 +50,7 @@ Specify which roles to assume for the request.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -91,4 +91,4 @@ $ mrm \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/mrmdir.1
+++ b/man/man1/mrmdir.1
@@ -42,7 +42,7 @@ Specify which roles to assume for the request.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -83,4 +83,4 @@ $ mrmdir \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/msign.1
+++ b/man/man1/msign.1
@@ -96,7 +96,7 @@ Set the role tags on objects created with the signed URL.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -137,4 +137,4 @@ $ msign \-vv ~~/stor/foo 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/man/man1/muntar.1
+++ b/man/man1/muntar.1
@@ -79,7 +79,7 @@ Set the role tags on created objects and directories.
 Authenticate as user under account.
 .TP
 \fB\fC\-u, \-\-url url\fR
-Manta base URL (such as \fB\fChttps://manta.us\-east.joyent.com\fR).
+Manta base URL (such as \fB\fChttps://us\-central.manta.mnx.io\fR).
 .TP
 \fB\fC\-v, \-\-verbose\fR
 Print debug output to stderr.  Repeat option to increase verbosity.
@@ -121,4 +121,4 @@ $ mfind \-vv ~~/stor 2>&1 | bunyan
 .PP
 DSA keys do not work when loaded via the SSH agent.
 .PP
-Report bugs at Github \[la]https://github.com/joyent/node-manta/issues\[ra]
+Report bugs at Github \[la]https://github.com/TritonDataCenter/node-manta/issues\[ra]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta",
-    "author": "MNX Clouc (mnx.io)",
+    "author": "MNX Cloud (mnx.io)",
     "description": "Manta Client API",
     "homepage": "http://apidocs.tritondatacenter.com/manta",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "manta",
-    "author": "Joyent (joyent.com)",
+    "author": "MNX Clouc (mnx.io)",
     "description": "Manta Client API",
-    "homepage": "http://apidocs.joyent.com/manta",
+    "homepage": "http://apidocs.tritondatacenter.com/manta",
     "repository": {
         "type": "git",
-        "url": "https://github.com/joyent/node-manta.git"
+        "url": "https://github.com/TritonDataCenter/node-manta.git"
     },
-    "version": "5.2.3",
+    "version": "5.3.0",
     "main": "./lib/index.js",
     "dependencies": {
         "assert-plus": "^1.0.0",
@@ -21,14 +21,14 @@
         "jsprim": "^1.3.0",
         "lomstream": "^1.1.0",
         "lstream": "~0.0.4",
-        "mime": "~1.2.11",
+        "mime": "~2.4.4",
         "moment": "^2.22.2",
         "once": "~1.4.0",
         "path-platform": "~0.0.1",
         "progbar": "^1.2.1",
         "readable-stream": "~1.1.9",
         "restify-clients": "~1.6.0",
-        "showdown": "~1.4.2",
+        "showdown": "~1.9.1",
         "smartdc-auth": "^2.4.1",
         "strsplit": "1.0.0",
         "tar": "~2.2.1",

--- a/test/integration/client.test.js
+++ b/test/integration/client.test.js
@@ -292,10 +292,10 @@ test('streams', function (t) {
         // The second is emitted by createWriteStream and contains the res
         // object. After the first one fires (where we are now), we'll add a
         // once listener for the next close event. That's the one we're looking
-        // for. This makes the test pass, but I'm not even sure how to provide
+        // for. This makes the test pass, but we're not sure how to provide
         // consumers guidance for what to do here. (Un)Luckily, there don't
         // actually seem to be consumers of this in the wild.
-        // In any event, this behavior has existed for so long, I'm wary of
+        // In any event, this behavior has existed for so long, we're wary of
         // changing it.
         w.once('close', function (res) {
             t.ok(res);

--- a/test/integration/mfind.test.js
+++ b/test/integration/mfind.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -131,8 +132,8 @@ test('mfind TESTDIR', function (t) {
 });
 
 /*
- * joyent/node-manta#251 specifying a path multiple times to mfind results in
- * crash.
+ * TritonDataCenter/node-manta#251 specifying a path multiple times to mfind
+ * results in crash.
  */
 test('mfind TESTDIR TESTDIR (same argument multiple times)', function (t) {
     forkExecWait({

--- a/test/integration/mjob-simple.test.js
+++ b/test/integration/mjob-simple.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -12,6 +13,7 @@ var assert = require('assert-plus');
 var path = require('path');
 var spawn = require('child_process').spawn;
 var test = require('tap').test;
+var testutils = require('../lib/utils');
 
 var logging = require('../lib/logging');
 
@@ -21,6 +23,12 @@ var logging = require('../lib/logging');
 var log = logging.createLogger();
 var MJOB = path.resolve(__dirname, '../../bin/mjob');
 
+var mantaVersion = testutils.mantaVersion(log);
+
+var testOpts = {
+    skip: mantaVersion !== '1' &&
+        'this Manta does not support jobs'
+};
 
 // ---- helper functions
 
@@ -68,7 +76,7 @@ function mjobExec(args, opts, cb) {
  * Note the usage of '-or "echo hello"' cuddled like that is ensuring we aren't
  * hitting <https://github.com/trentm/node-dashdash/issues/8>.
  */
-test('mjob create --close -or "echo hello"', function (t) {
+test('mjob create --close -or "echo hello"', testOpts, function (t) {
     var args = ['create', '--close', '-or', 'echo hello'];
     mjobExec(args, function (err, stdout, stderr) {
         t.ifError(err, err);

--- a/test/integration/mln.test.js
+++ b/test/integration/mln.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -14,6 +15,8 @@ var path = require('path');
 var test = require('tap').test;
 var vasync = require('vasync');
 var sprintf = require('extsprintf').sprintf;
+var testutils = require('../lib/utils');
+
 
 var logging = require('../lib/logging');
 
@@ -39,6 +42,13 @@ var TESTTREE = [
         type: 'directory'
     }
 ];
+
+var mantaVersion = testutils.mantaVersion(log);
+
+var testOpts = {
+    skip: mantaVersion !== '1' &&
+        'this Manta does not support snapLinks'
+};
 
 /*
  * Create three regular UNIX text files (linefeed separated, with a terminating
@@ -84,7 +94,7 @@ function unlinkIfExists(targ) {
 
 // ---- tests
 
-test('setup: create test tree at ' + TESTDIR, function (t) {
+test('setup: create test tree at ' + TESTDIR, testOpts, function (t) {
     var tmpFile = path.join(TMPDIR, 'node-manta-test-tmp-file-' + process.pid);
 
     vasync.forEachPipeline({
@@ -130,7 +140,7 @@ test('setup: create test tree at ' + TESTDIR, function (t) {
 });
 
 
-test('mln ', function (t) {
+test('mln ', testOpts, function (t) {
     var argv1 = [
         MLN,
         sprintf('%s/%02d.data', TESTDIR, 1),
@@ -177,7 +187,7 @@ test('mln ', function (t) {
 /*
  * Link a file using the role-tag option and verify the role-tag header
  * is set on the object. This verifies the fix for
- * https://github.com/joyent/node-manta/issues/333. This test requires
+ * https://github.com/TritonDataCenter/node-manta/issues/333. This test requires
  * a role to be configured in triton to work properly so it is condtional
  * upon the user setting MANTA_TEST_ROLE in the environment.
  */
@@ -224,7 +234,7 @@ if (process.env.MANTA_TEST_ROLE) {
 }
 
 
-test('cleanup: rm test tree ' + TESTDIR, function (t) {
+test('cleanup: rm test tree ' + TESTDIR, testOpts, function (t) {
     // Sanity checks that we don't `mrm -r` a non-test dir.
     assert.ok(TESTDIR);
     assert.ok(TESTDIR.indexOf('node-manta-test') !== -1);
@@ -236,7 +246,7 @@ test('cleanup: rm test tree ' + TESTDIR, function (t) {
 });
 
 
-test('cleanup: rm tmp directory ' + TMPDIR, function (t) {
+test('cleanup: rm tmp directory ' + TMPDIR, testOpts, function (t) {
     var tmpFile = path.join(TMPDIR, 'node-manta-test-tmp-file-' + process.pid);
 
     unlinkIfExists(tmpFile);

--- a/test/integration/mmkdir.test.js
+++ b/test/integration/mmkdir.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -39,7 +40,7 @@ var testOpts = {
 /*
  * Create a directory using the role-tag option and verify the role-tag header
  * is set on the object. This verifies the fix for
- * https://github.com/joyent/node-manta/issues/333. This test requires
+ * https://github.com/TritonDataCenter/node-manta/issues/333. This test requires
  * a role to be configured in triton to work properly so it is condtional
  * upon the user setting MANTA_TEST_ROLE in the environment.
  */

--- a/test/integration/mput.test.js
+++ b/test/integration/mput.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -123,7 +124,7 @@ test('setup: create test tree at ' + TESTDIR, function (t) {
 
 /*
  * Put a file with a custom header whose value include colons. This verifies the
- * fix for https://github.com/joyent/node-manta/issues/312.
+ * fix for https://github.com/TritonDataCenter/node-manta/issues/312.
  */
 test('mput with custom header value with colons', function (t) {
     // Expect the header to include the full timestamp including the colons
@@ -170,7 +171,7 @@ test('mput with custom header value with colons', function (t) {
 /*
  * Put a file using the role-tag option and verify the role-tag header
  * is set on the object. This verifies the fix for
- * https://github.com/joyent/node-manta/issues/333. This test requires
+ * https://github.com/TritonDataCenter/node-manta/issues/333. This test requires
  * a role to be configured in triton to work properly so it is condtional
  * upon the user setting MANTA_TEST_ROLE in the environment.
  */

--- a/test/integration/muntar.test.js
+++ b/test/integration/muntar.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 var exec = require('child_process').exec;
@@ -109,7 +110,8 @@ var cases = [
         ]
     },
     {
-        // Skipping, see <https://github.com/joyent/node-manta/issues/259>
+        // Skipping, see
+        // <https://github.com/TritonDataCenter/node-manta/issues/259>
         skip: true,
         tarpath: 'corpus/259-emptydir.tar',
         checks: [

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 var assert = require('assert-plus');
@@ -14,6 +15,7 @@ var VError = require('verror');
 var BINDIR = path.resolve(__dirname, '../../bin');
 var MLS = path.resolve(BINDIR, 'mls');
 var MMPU = path.resolve(BINDIR, 'mmpu');
+var MINFO = path.resolve(BINDIR, 'minfo');
 
 /*
  * Call `mls` on the given path and return a JSON array of objects for each
@@ -102,8 +104,28 @@ function isMpuEnabledSync(log) {
     return (true);
 }
 
+function mantaVersion(log) {
+    assert.string(process.env.MANTA_USER, 'process.env.MANTA_USER');
+    assert.object(log, 'log');
+
+    var checkPath = format('/%s/stor', process.env.MANTA_USER);
+    var info = JSON.parse(execFileSync(MINFO, ['-j', checkPath], {
+        stdio: 'pipe', // to not emit stderr to parent's stderr
+        encoding: 'utf8'
+    }).trim());
+    log.trace(JSON.stringify(info));
+    var server = info.server;
+    if (server === 'Manta') {
+        return ('1');
+    } else {
+        var s = server.split('/');
+        return (s[1]);
+    }
+}
+
 
 module.exports = {
     isMpuEnabledSync: isMpuEnabledSync,
+    mantaVersion: mantaVersion,
     mls: mls
 };

--- a/test/unit/options.test.js
+++ b/test/unit/options.test.js
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -77,7 +78,7 @@ function inputObject(testObj) {
 /*
  * Test that specifying the --help option with no manta URL specified does not
  * result in a warning about the missing URL. This verifies the fix for
- * https://github.com/joyent/node-manta/issues/328.
+ * https://github.com/TritonDataCenter/node-manta/issues/328.
  */
 test('Run commands with --help with no manta URL specified', function (t) {
     vasync.forEachPipeline({
@@ -92,7 +93,7 @@ test('Run commands with --help with no manta URL specified', function (t) {
 /*
  * Test that specifying the --version option with no manta URL specified does
  * not result in a warning about the missing URL. This verifies the fix for
- * https://github.com/joyent/node-manta/issues/328.
+ * https://github.com/TritonDataCenter/node-manta/issues/328.
  */
 test('Run commands with --version with no manta URL specified', function (t) {
     vasync.forEachPipeline({

--- a/tools/changelog-issue-line
+++ b/tools/changelog-issue-line
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # Copyright 2018 Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
-# Generate a line for the changelog given a GitHub issue number or Joyent Jira
+# Generate a line for the changelog given a GitHub issue number or Jira
 # ticket identifier
 
 github_issue_re='^[1-9][0-9]*$'
@@ -22,7 +23,7 @@ usage() {
 	cat <<-EOF
 	Usage: $prog [-hv] [-o <org>] [-r <repo>] issue# [issue2# issue3# ...]
 
-	Generate a line for the changelog given a GitHub issue number or Joyent
+	Generate a line for the changelog given a GitHub issue number or
 	Jira ticket identifier
 
 	Options

--- a/tools/mk/Makefile.defs
+++ b/tools/mk/Makefile.defs
@@ -7,6 +7,7 @@
 
 #
 # Copyright (c) 2014, Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
@@ -32,9 +33,9 @@
 TOP := $(shell pwd)
 
 #
-# Mountain Gorilla-spec'd versioning.
-# See "Package Versioning" in MG's README.md:
-# <https://mo.joyent.com/mountain-gorilla/blob/master/README.md#L139-200>
+# Triton-spec'd versioning.
+# See "Package Versioning" in Triton's Engineering guide:
+# <https://github.com/TritonDataCenter/triton/blob/master/docs/developer-guide/release-engineering.md#package-versioning>
 #
 # Need GNU awk for multi-char arg to "-F".
 _AWK := $(shell (which gawk >/dev/null && echo gawk) \

--- a/tools/mk/Makefile.targ
+++ b/tools/mk/Makefile.targ
@@ -7,6 +7,7 @@
 
 #
 # Copyright (c) 2014, Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
@@ -36,7 +37,7 @@
 #
 #	xref	Generates cscope (source cross-reference index)
 #
-# For details on what these targets are supposed to do, see the Joyent
+# For details on what these targets are supposed to do, see the Triton
 # Engineering Guide.
 #
 # To make use of these targets, you'll need to set some of these variables. Any
@@ -139,7 +140,7 @@ endif
 
 #
 # Targets. For descriptions on what these are supposed to do, see the
-# Joyent Engineering Guide.
+# Triton Engineering Guide.
 #
 
 #

--- a/tools/test-in-smartos-container.sh
+++ b/tools/test-in-smartos-container.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 #
 # Copyright 2016, Joyent, Inc.
+# Copyright 2022 MNX Cloud, Inc.
 #
 
 #
 # Provision a SmartOS container (using the given 'triton' profile) and
 # run the test suite with a number of node versions.
 #
-# This is being used for automatic tests after commit in Joyent's
+# This is being used for automatic tests after commit in the Triton
 # internal Jenkins. This is likely quite brittle right now.
 #
 
@@ -180,7 +181,7 @@ pkgin -y in git gmake >\$miscLogPath 2>&1
 if [[ -d node-manta ]]; then
     (cd node-manta && git pull) >\$miscLogPath 2>&1
 else
-    git clone https://github.com/joyent/node-manta.git >\$miscLogPath 2>&1
+    git clone https://github.com/TritonDataCenter/node-manta.git >\$miscLogPath 2>&1
 fi
 if [[ -n "$optBranch" ]]; then
     (cd node-manta && git checkout nouveau) >\$miscLogPath 2>&1


### PR DESCRIPTION
Sorry this is so big.

There's 3 issues addressed here:

* #389 minfo should support json output - this change is in `bin/minfo` only
* #388 Testing v1 features should be skipped unless mantav1 - this change is mostly in the `test` dir
* TOOLS-2543 MNX Tooling updates - this is all over the place due to joyent -> mnx URL changes.