### PR TITLE
MANTA-5462 AssertionError with node v10-v16 and OpenSSL3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ See `CONTRIBUTING.md` for details on how to update this file
 
 ## not yet released
 
+## 5.3.2
+
+- [#393](https://github.com/TritonDataCenter/node-manta/issues/393) AssertionError with node <=16 and OpenSSL3
+
 ## 5.3.1
 
 - [#391](https://github.com/TritonDataCenter/node-manta/issues/391) TypeError: mime.extension is not a function
@@ -354,8 +358,8 @@ errors are no longer fatal unless none of the arguments are found)
 ## 1.3.0
 
 - RBAC Support
-    * add --role and --role-tag options
-    * add support for authentication as user (MANTA_ACCOUNT, MANTA_USER)
+  - add --role and --role-tag options
+  - add support for authentication as user (MANTA_ACCOUNT, MANTA_USER)
 
 ## v1.2.8
 

--- a/bin/mmpu
+++ b/bin/mmpu
@@ -2,7 +2,14 @@
 // -*- mode: js -*-
 /*
  * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
+
+// Workaround a bug in node v10-16 when using OpenSSL 3 without ssh-agent.
+// This needs to be set before the crypto module is loaded.
+if (typeof (process.env.OPENSSL_CONF) === 'undefined') {
+    process.env['OPENSSL_CONF'] = '';
+}
 
 var assert = require('assert');
 var crypto = require('crypto');

--- a/bin/mput
+++ b/bin/mput
@@ -2,7 +2,14 @@
 // -*- mode: js -*-
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
+
+// Workaround a bug in node v10-16 when using OpenSSL 3 without ssh-agent.
+// This needs to be set before the crypto module is loaded.
+if (typeof (process.env.OPENSSL_CONF) === 'undefined') {
+    process.env['OPENSSL_CONF'] = '';
+}
 
 var crypto = require('crypto');
 var fs = require('fs');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,11 @@
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
+// Copyright 2023 MNX Cloud, Inc.
+
+// Workaround a bug in node v10-16 when using OpenSSL 3 without ssh-agent.
+// This needs to be set before the crypto module is loaded.
+if (typeof (process.env.OPENSSL_CONF) === 'undefined') {
+    process.env['OPENSSL_CONF'] = '';
+}
 
 var auth = require('smartdc-auth');
 var cc = require('./create_client');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/TritonDataCenter/node-manta.git"
     },
-    "version": "5.3.1",
+    "version": "5.3.2",
     "main": "./lib/index.js",
     "dependencies": {
         "assert-plus": "^1.0.0",


### PR DESCRIPTION
Commands before this fix will produce the following error:

```
AssertionError [ERR_ASSERTION]: value
```

* lib/index.js fixes most commands
* mput and mmpu import crypto before importing the rest of manta, so they need to be fixed in the executable

After these changes all commands behave normally.