### PR TITLE
node-manta#400: msync --completion returns error if manta env vars are unset node-manta#401: Newer npm breaks make cutarelease

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ See `CONTRIBUTING.md` for details on how to update this file
 
 ## not yet released
 
+## 5.4.1
+
+- [#400](https://github.com/TritonDataCenter/node-manta/issues/400) msync --completion returns error if manta env vars are unset
+- [#401](https://github.com/TritonDataCenter/node-manta/issues/401) Newer npm breaks make cutarelease
+
 ## 5.4.0
 
 - [MANTA-5463](https://smartos.org/bugview/MANTA-5463) muntar has outlived its usefulness
@@ -12,7 +17,7 @@ See `CONTRIBUTING.md` for details on how to update this file
 
 ## 5.3.2
 
-- [#393](https://github.com/TritonDataCenter/node-manta/issues/393) AssertionError with node <=16 and OpenSSL3
+- [#393](https://github.com/TritonDataCenter/node-manta/issues/393) AssertionError with node `<=16` and OpenSSL3
 
 ## 5.3.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright 2019 Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -106,7 +107,7 @@ cutarelease: $(COMPLETION_FILE) versioncheck
 	@which json 2>/dev/null 1>/dev/null && \
 	    ver=$(shell json -f package.json version) && \
 	    name=$(shell json -f package.json name) && \
-	    publishedVer=$(shell npm view -j $(shell json -f package.json name)@$(shell json -f package.json version) version 2>/dev/null) && \
+	    publishedVer=$(shell npm view -j $(shell json -f package.json name) | grep $(shell json -f package.json version)) && \
 	    if [[ -n "$$publishedVer" ]]; then \
 		echo "error: $$name@$$ver is already published to npm"; \
 		exit 1; \

--- a/bin/msync
+++ b/bin/msync
@@ -182,6 +182,26 @@ var OPTIONS_PARSER = dashdash.createParser({
 var opts;
 try {
     opts = OPTIONS_PARSER.parse(process.argv);
+    if (opts.completion) {
+        /*
+         * To ensure that all our stdout is written before 'process.exit()'
+         * terminates, we set stdout to blocking. This is an issue when
+         * (a) node v4 or later is used and (b) at least when exec'd by node
+         * as in test/completion.test.js. See
+         * https://gist.github.com/misterdjules/3aa4c77d8f881ffccba3b6e6f0050d03
+         * for some discussion. An alternative would be to exit the the node
+         * process without 'process.exit'.
+         */
+        if (process.stdout._handle &&
+                typeof (process.stdout._handle.setBlocking) === 'function')
+        {
+                process.stdout._handle.setBlocking(true);
+        }
+        console.log(OPTIONS_PARSER.bashCompletion({
+            name: path.basename(process.argv[1])
+        }));
+        process.exit(0);
+    }
     manta.checkBinEnv(opts);
 } catch (e) {
     usage(e.message);
@@ -228,26 +248,6 @@ opts.exclude.forEach(function (s) {
 });
 
 var args = opts._args;
-if (opts.completion) {
-    /*
-     * To ensure that all our stdout is written before 'process.exit()'
-     * terminates, we set stdout to blocking. This is an issue when
-     * (a) node v4 or later is used and (b) at least when exec'd by node
-     * as in test/completion.test.js. See
-     * https://gist.github.com/misterdjules/3aa4c77d8f881ffccba3b6e6f0050d03
-     * for some discussion. An alternative would be to exit the the node
-     * process without 'process.exit'.
-     */
-    if (process.stdout._handle &&
-            typeof (process.stdout._handle.setBlocking) === 'function')
-    {
-            process.stdout._handle.setBlocking(true);
-    }
-    console.log(OPTIONS_PARSER.bashCompletion({
-        name: path.basename(process.argv[1])
-    }));
-    process.exit(0);
-}
 
 // XXX maybe make this more like rsync?
 if (args.length !== 2) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "manta",
-    "version": "5.4.0",
+    "version": "5.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "manta",
-            "version": "5.4.0",
+            "version": "5.4.1",
             "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/TritonDataCenter/node-manta.git"
     },
-    "version": "5.4.0",
+    "version": "5.4.1",
     "main": "./lib/index.js",
     "dependencies": {
         "assert-plus": "^1.0.0",


### PR DESCRIPTION
Fixes #400, #401.

Testing:

```
$ env | grep MANTA
$ make test TEST_FILTER=unit
test/unit/completion.test.js ........................ 54/54
test/unit/options.test.js ........................... 60/60
test/unit/trackmarker.test.js ....................... 73/73
test/unit/utils.test.js ............................. 32/32
total ............................................. 219/219

  219 passing (4s)

  ok
$ ./bin/msync --completion | head
#!/bin/bash
#
# Bash completion generated for 'msync' at Mon Sep 18 2023 16:17:55 GMT-0700 (Pacific Daylight Time).
#
# The original template lives here:
# https://github.com/trentm/node-dashdash/blob/master/etc/dashdash.bash_completion.in
#

#
# Copyright 2016 Trent Mick
```

The changes for `make cutarelease` were used to publish the *last* release.