### PR TITLE
MANTA-5466 Update smartdc-auth for ed25519 key support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ See `CONTRIBUTING.md` for details on how to update this file
 
 ## not yet released
 
+## 5.4.2
+
+- [MANTA-5466](https://smartos.org/bugview/MANTA-5466) Update smartdc-auth for ed25519 key support
+
 ## 5.4.1
 
 - [#400](https://github.com/TritonDataCenter/node-manta/issues/400) msync --completion returns error if manta env vars are unset

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "manta",
-    "version": "5.4.1",
+    "version": "5.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "manta",
-            "version": "5.4.1",
+            "version": "5.4.2",
             "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",
@@ -30,7 +30,7 @@
                 "readable-stream": "~1.1.9",
                 "restify-clients": "~1.6.0",
                 "showdown": "~1.9.1",
-                "smartdc-auth": "^2.4.1",
+                "smartdc-auth": "^2.6.0",
                 "strsplit": "1.0.0",
                 "tar": "~2.2.1",
                 "uuid": "~2.0.2",
@@ -1148,13 +1148,13 @@
             "dev": true
         },
         "node_modules/http-signature": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-            "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^2.0.2",
-                "sshpk": "^1.14.1"
+                "sshpk": "^1.18.0"
             },
             "engines": {
                 "node": ">=0.10"
@@ -2718,18 +2718,18 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/smartdc-auth": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/smartdc-auth/-/smartdc-auth-2.5.9.tgz",
-            "integrity": "sha512-tSVRtJPzbFY4Ak8n4bb9nkjyGsFz+db+X+KJUDhojgZkzPXEVaPBgKsnXdrvRyBiOR6geZtqi1LKMRJ8ku8d1g==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/smartdc-auth/-/smartdc-auth-2.6.0.tgz",
+            "integrity": "sha512-yLtMaRcim8aOWtYpyuE5WHehR7Dtko0uR6Z+12qoW4i7tQmHy50d0RXgI9QYdWGScbdMyUhimPJlhmtOCZkqGg==",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "bunyan": "1.8.12",
                 "clone": "0.1.5",
                 "dashdash": "1.10.1",
-                "http-signature": "^1.0.2",
+                "http-signature": "1.4.0",
                 "once": "1.3.0",
-                "sshpk": "^1.13.2",
-                "sshpk-agent": "^1.3.0",
+                "sshpk": "^1.18.0",
+                "sshpk-agent": "^1.8.1",
                 "vasync": "^2.2.1"
             },
             "bin": {
@@ -2917,9 +2917,9 @@
             "dev": true
         },
         "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/TritonDataCenter/node-manta.git"
     },
-    "version": "5.4.1",
+    "version": "5.4.2",
     "main": "./lib/index.js",
     "dependencies": {
         "assert-plus": "^1.0.0",
@@ -31,7 +31,7 @@
         "readable-stream": "~1.1.9",
         "restify-clients": "~1.6.0",
         "showdown": "~1.9.1",
-        "smartdc-auth": "^2.4.1",
+        "smartdc-auth": "^2.6.0",
         "strsplit": "1.0.0",
         "tar": "~2.2.1",
         "uuid": "~2.0.2",


### PR DESCRIPTION
Tested this against minimanta (which needed no changes):

Before change:

```
$ mls ~~
mls: InvalidAlgorithmError: ED25519 type keys are not supported
```

After:

```
$ mls ~~
keys/
```

`make check` and `make test TEST_FILTER=unit` succeeded.

See also: TritonDataCenter/manta-muskie/pull/101